### PR TITLE
travis 上でテストが通るように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "agreed-client": "^0.3.0",
     "agreed-server": "^0.2.1",
+    "colo": "^0.3.2",
     "minimist": "^1.2.0"
   }
 }

--- a/test/bin/not_passed.js
+++ b/test/bin/not_passed.js
@@ -13,7 +13,9 @@ plzPort().then((port) => {
     assert(result.indexOf('✗ fail') >= 0);
     proc.kill();
 
-    process.exit(0);
+    setTimeout(() => {
+      process.exit(0);
+    }, 500);
   }, 1000);
 });
 

--- a/test/bin/not_passed.js
+++ b/test/bin/not_passed.js
@@ -8,9 +8,10 @@ plzPort().then((port) => {
   const proc = cp.exec(`node ${process.cwd()}/bin/agreed-server.js --port ${port} --path ${not_pass}`);
   setTimeout(() => {
     const result = cp.execSync(`node ${process.cwd()}/bin/agreed-client.js --port ${port} --path ${pass}`).toString();
+
     console.log(result);
     assert(result.indexOf('✗ fail') >= 0);
     proc.kill();
-  }, 100);
+  }, 1000);
 });
 

--- a/test/bin/not_passed.js
+++ b/test/bin/not_passed.js
@@ -12,6 +12,8 @@ plzPort().then((port) => {
     console.log(result);
     assert(result.indexOf('✗ fail') >= 0);
     proc.kill();
+
+    process.exit(0);
   }, 1000);
 });
 

--- a/test/bin/pass.js
+++ b/test/bin/pass.js
@@ -11,6 +11,8 @@ plzPort().then((port) => {
     assert(result.indexOf('✔ pass') >= 0);
     proc.kill();
 
-    process.exit(0);
+    setTimeout(() => {
+      process.exit(0);
+    }, 500);
   }, 1000);
 });

--- a/test/bin/pass.js
+++ b/test/bin/pass.js
@@ -10,5 +10,7 @@ plzPort().then((port) => {
     console.log(result);
     assert(result.indexOf('✔ pass') >= 0);
     proc.kill();
+
+    process.exit(0);
   }, 1000);
 });

--- a/test/bin/pass.js
+++ b/test/bin/pass.js
@@ -10,5 +10,5 @@ plzPort().then((port) => {
     console.log(result);
     assert(result.indexOf('✔ pass') >= 0);
     proc.kill();
-  }, 100);
+  }, 1000);
 });


### PR DESCRIPTION
- dependency で colo が抜けていたので追加しました。
- agreed-server 起動してからの wait が 100 msec だと travis 上では間に合わない (自分の環境も間に合いませんでした) ようだったので、1000 msec に増やしました。
- テストケースの最後で process.exit(0) で明示的に抜けないと travis 上で timeout まで待つ挙動 (https://travis-ci.org/kt3k/agreed/builds/151708767) になってテストが通らないようだったので、process.eixt(0) を追加しました。(この修正は、自分のローカル上では必要なかったので、完全に travis 向けの修正です)

自分のアカウントの travis 上ではテストが通っています。 https://travis-ci.org/kt3k/agreed/builds/151710539