### PR TITLE
Feature Request: hot replacement flags

### DIFF
--- a/packages/core/lib/check/completion.js
+++ b/packages/core/lib/check/completion.js
@@ -2,14 +2,14 @@
 
 const pathToRegexp = require("path-to-regexp");
 const path = require("path");
-const requireUncached = require("../require_hook/requireUncached");
+const requireAgree = require("../require_hook/requireAgree");
 
 const DEFAULT_REQUEST = require("./defaultRequest");
 const DEFAULT_RESPONSE = require("./defaultResponse");
 
 module.exports = (agree, base, opts = {}) => {
   if (typeof agree === "string") {
-    agree = normalizedRequire(agree, base);
+    agree = normalizedRequire(agree, base, opts.hot);
   }
 
   if (!agree) {
@@ -17,11 +17,11 @@ module.exports = (agree, base, opts = {}) => {
   }
 
   if (typeof agree.request === "string") {
-    agree.request = normalizedRequire(agree.request, base);
+    agree.request = normalizedRequire(agree.request, base, opts.hot);
   }
 
   if (typeof agree.response === "string") {
-    agree.response = normalizedRequire(agree.response, base);
+    agree.response = normalizedRequire(agree.response, base, opts.hot);
   }
 
   if (!agree.request) {
@@ -110,16 +110,20 @@ module.exports = (agree, base, opts = {}) => {
   agree.response.body = agree.response.body || DEFAULT_RESPONSE.body;
 
   if (typeof agree.response.schema === "string") {
-    agree.response.schema = normalizedRequire(agree.response.schema, base);
+    agree.response.schema = normalizedRequire(
+      agree.response.schema,
+      base,
+      opts.hot
+    );
   }
 
   return agree;
 };
 
-function normalizedRequire(file, base) {
+function normalizedRequire(file, base, hot) {
   return path.isAbsolute(file)
-    ? requireUncached(file)
-    : requireUncached(path.join(base, file));
+    ? requireAgree(file, hot)
+    : requireAgree(path.join(base, file), hot);
 }
 
 function toLowerCaseKeys(obj) {

--- a/packages/core/lib/require_hook/requireAgree.js
+++ b/packages/core/lib/require_hook/requireAgree.js
@@ -1,0 +1,5 @@
+const requireUncached = require("./requireUncached");
+
+module.exports = (agree, hot = true) => {
+  return hot ? requireUncached(agree) : require(agree);
+};

--- a/packages/core/lib/require_hook/requireUncached.js
+++ b/packages/core/lib/require_hook/requireUncached.js
@@ -1,4 +1,4 @@
-module.exports = module => {
-  delete require.cache[require.resolve(module)];
+module.exports = (module, hot = true) => {
+  if (hot) delete require.cache[require.resolve(module)];
   return require(module);
 };

--- a/packages/core/lib/require_hook/requireUncached.js
+++ b/packages/core/lib/require_hook/requireUncached.js
@@ -1,4 +1,4 @@
-module.exports = (module, hot = true) => {
-  if (hot) delete require.cache[require.resolve(module)];
+module.exports = module => {
+  delete require.cache[require.resolve(module)];
   return require(module);
 };

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -11,7 +11,8 @@ const register = require("./register");
 const format = require("./template/format");
 const hasTemplate = require("./template/hasTemplate").hasTemplate;
 const bind = require("./template/bind");
-const requireUncached = require("./require_hook/requireUncached");
+const requireAgree = require("./require_hook/requireAgree");
+const requireUncache = require("./require_hook/requireUncached");
 const EventEmitter = require("events").EventEmitter;
 
 class Server {
@@ -27,7 +28,7 @@ class Server {
   }
   useMiddleware(req, res, next) {
     const agrees = (
-      this.agrees || requireUncached(this.agreesPath, this.options.hot)
+      this.agrees || requireAgree(this.agreesPath, this.options.hot)
     ).map(agree => completion(agree, this.base, this.options));
 
     extract

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -26,9 +26,9 @@ class Server {
     register(options.register);
   }
   useMiddleware(req, res, next) {
-    const agrees = (this.agrees || requireUncached(this.agreesPath)).map(
-      agree => completion(agree, this.base, this.options)
-    );
+    const agrees = (
+      this.agrees || requireUncached(this.agreesPath, this.options.hot)
+    ).map(agree => completion(agree, this.base, this.options));
 
     extract
       .incomingRequest(req)

--- a/packages/core/test/lib/server.strict.js
+++ b/packages/core/test/lib/server.strict.js
@@ -37,7 +37,8 @@ test("server: check strict mode - status code", () => {
       }
     ],
     port: 0,
-    strict: true
+    strict: true,
+    hot: true
   });
 
   server.on("listening", () => {
@@ -90,7 +91,8 @@ test("server: check strict mode - message", () => {
       }
     ],
     port: 0,
-    strict: true
+    strict: true,
+    hot: true
   });
 
   server.on("listening", () => {
@@ -156,7 +158,8 @@ test("server: check strict mode - candidates", () => {
       }
     ],
     port: 0,
-    strict: true
+    strict: true,
+    hot: true
   });
 
   server.on("listening", () => {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -21,6 +21,12 @@ Usage as CLI
 $ agreed-server --path ./test/agreed.json --port 10101
 ```
 
+- if you want to boot agreed server as disable hot replacement.
+
+```
+$ agreed-server --path ./test/agreed.json --port 10101 --hot false
+```
+
 Usage as programming
 
 ```js

--- a/packages/server/bin/agreed-server.js
+++ b/packages/server/bin/agreed-server.js
@@ -12,14 +12,12 @@ const argv = minimist(process.argv.slice(2), {
     'proxy',
     'proxy-prefix-path'
   ],
-  boolean: [
-    'help',
-    'version',
-    'logging',
-    'strict'
-  ],
+  boolean: ['help', 'version', 'logging', 'strict', 'hot'],
   alias: {
     l: 'logging'
+  },
+  default: {
+    hot: true
   }
 });
 const path = require('path');
@@ -44,6 +42,7 @@ Options:
   --proxy-prefix-path <prefix>       Proxy server path prefix.
   -l, --logging                      Logs requests in console.
   --strict                           Run strict mode.
+  --hot                              Hot Replacement agree files. Default true
 
 Examples:
   agreed-server --path ./agreed.js --port 4000

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -25,7 +25,7 @@ module.exports = (opts) => {
 
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
-  
+
   if (stat) {
     if (staticPrefixPath) {
       app.use(staticPrefixPath, express.static(path.join(process.cwd(), stat)));
@@ -72,12 +72,11 @@ module.exports = (opts) => {
 
   const notifier = agreed.server.notifier;
 
-  return { 
+  return {
     // low level
-    app, 
+    app,
     // high level
     createServer,
     notifier
   };
 };
-

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -4,6 +4,25 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@agreed/core": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@agreed/core/-/core-0.1.0.tgz",
+			"integrity": "sha512-lhYtM0fvlGKF2yTa/9YSRmwlLfQWFA28WtemKUOqB5moPMzScFD7vKp6ZHBO4LcI3OPC2sPIaWMQHiW0WI6PLw==",
+			"requires": {
+				"@types/node": "^10.11.5",
+				"json5": "^2.0.0",
+				"jsonschema": "^1.2.4",
+				"path-to-regexp": "^1.5.3",
+				"stable": "^0.1.8",
+				"typescript": "^3.1.1",
+				"yamljs": "^0.3.0"
+			}
+		},
+		"@types/node": {
+			"version": "10.17.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.11.tgz",
+			"integrity": "sha512-dNd2pp8qTzzNLAs3O8nH3iU9DG9866KHq9L3ISPB7DOGERZN81nW/5/g/KzMJpCU8jrbCiMRBzV9/sCEdRosig=="
+		},
 		"accepts": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -11,6 +30,14 @@
 			"requires": {
 				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"requires": {
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-flatten": {
@@ -27,8 +54,7 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"basic-auth": {
 			"version": "2.0.1",
@@ -59,7 +85,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -79,8 +104,7 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"content-disposition": {
 			"version": "0.5.2",
@@ -272,14 +296,12 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"glob": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
 			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -312,7 +334,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -328,14 +349,23 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
 			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
 		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+		},
 		"json5": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
 			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.0"
 			}
+		},
+		"jsonschema": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.5.tgz",
+			"integrity": "sha512-kVTF+08x25PQ0CjuVc0gRM9EUPb0Fe9Ln/utFOgcdxEIOHuU7ooBk/UPTd7t1M91pP35m0MU1T8M5P7vP1bRRw=="
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -374,7 +404,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -382,8 +411,7 @@
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-			"dev": true
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"morgan": {
 			"version": "1.9.1",
@@ -430,7 +458,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -443,8 +470,15 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+		},
+		"path-to-regexp": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+			"requires": {
+				"isarray": "0.0.1"
+			}
 		},
 		"plz-port": {
 			"version": "1.0.0",
@@ -535,6 +569,16 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
 			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
 		"statuses": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -548,6 +592,11 @@
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.18"
 			}
+		},
+		"typescript": {
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+			"integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -567,8 +616,16 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+		},
+		"yamljs": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+			"integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"glob": "^7.0.5"
+			}
 		}
 	}
 }

--- a/packages/server/test/app.js
+++ b/packages/server/test/app.js
@@ -9,6 +9,7 @@ test('agreed-server: instance app', () => {
   const { app, createServer } = agreedServer({
     path: './test/agreed',
     port: '0',
+    hot: false
   });
 
   const server = createServer(app);
@@ -20,7 +21,7 @@ test('agreed-server: instance app', () => {
       path: '/shops/test',
       port: port,
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/json'
       }
     };
     http.get(options, (res) => {
@@ -38,7 +39,8 @@ test('agreed-server: call foobarbaz', () => {
   const { app, createServer } = agreedServer({
     path: './test/agreed',
     port: '0',
-    callNextWhenNotFound: true
+    callNextWhenNotFound: true,
+    hot: true
   });
 
   app.use('/foobarbaz', (req, res, next) => {
@@ -52,7 +54,7 @@ test('agreed-server: call foobarbaz', () => {
       host: 'localhost',
       method: 'GET',
       path: '/foobarbaz',
-      port: port,
+      port: port
     };
     http.get(options, (res) => {
       server.close();
@@ -62,4 +64,3 @@ test('agreed-server: call foobarbaz', () => {
     });
   });
 });
-


### PR DESCRIPTION
# About

`agreed` always replacements agree files.
I want to use as disable hot replacement. 
Actually I have doing in the staging server.

# Solution

- append flags as `--hot`. (default `true` because, not modify currently behavior)