### PR TITLE
feat: apply hot replacement flag to typescript

### DIFF
--- a/packages/core/lib/register.js
+++ b/packages/core/lib/register.js
@@ -4,8 +4,8 @@ const json5Hook = require("./require_hook/json5");
 const yamlHook = require("./require_hook/yaml");
 const tsHook = require("./require_hook/typescript");
 
-module.exports = (option = {}) => {
+module.exports = (option = {}, hot = true) => {
   json5Hook();
   yamlHook();
-  tsHook(option);
+  tsHook(option, hot);
 };

--- a/packages/core/lib/require_hook/typescript.js
+++ b/packages/core/lib/require_hook/typescript.js
@@ -13,11 +13,13 @@ const transpile = (src, options = {}) => {
   return res;
 };
 
-module.exports = options => {
+module.exports = (options, hot) => {
   require.extensions[".ts"] = (module, file) => {
     const src = fs.readFileSync(file).toString("utf-8");
     const agree = transpile(src, options);
     module._compile(agree, file);
-    delete require.cache[file];
+    if (hot) {
+      delete require.cache[file];
+    }
   };
 };

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -12,7 +12,6 @@ const format = require("./template/format");
 const hasTemplate = require("./template/hasTemplate").hasTemplate;
 const bind = require("./template/bind");
 const requireAgree = require("./require_hook/requireAgree");
-const requireUncache = require("./require_hook/requireUncached");
 const EventEmitter = require("events").EventEmitter;
 
 class Server {
@@ -24,7 +23,7 @@ class Server {
     }
     this.options = options;
     this.notifier = new EventEmitter();
-    register(options.register);
+    register(options.register, this.options.hot);
   }
   useMiddleware(req, res, next) {
     const agrees = (


### PR DESCRIPTION
The hot replacement flag (https://github.com/recruit-tech/agreed/pull/87) is applied only for js.

When it is written by typescript, `--hot` is disabled because require.cache is deleted here(https://github.com/recruit-tech/agreed/blob/master/packages/core/lib/require_hook/typescript.js#L21).

I am sorry If I have misunderstood.