### PR TITLE
feat: add typed-cache-path options

### DIFF
--- a/packages/core/lib/check/completion.js
+++ b/packages/core/lib/check/completion.js
@@ -106,6 +106,7 @@ module.exports = (agree, base, opts = {}) => {
       agree.response.headers
     );
   }
+  console.log(agree);
 
   agree.response.body = agree.response.body || DEFAULT_RESPONSE.body;
 

--- a/packages/core/lib/check/completion.js
+++ b/packages/core/lib/check/completion.js
@@ -106,7 +106,6 @@ module.exports = (agree, base, opts = {}) => {
       agree.response.headers
     );
   }
-  console.log(agree);
 
   agree.response.body = agree.response.body || DEFAULT_RESPONSE.body;
 

--- a/packages/core/lib/require_hook/typescript.js
+++ b/packages/core/lib/require_hook/typescript.js
@@ -30,6 +30,7 @@ const takeCache = (options) => {
 const getCacheAgree = (file, cache, mtimeMs) => {
   if (cache && cache[file]) {
     if (cache[file].mtimeMs === mtimeMs) {
+      console.log("cached! %s", file);
       return cache[file];
     }
   }
@@ -63,7 +64,7 @@ module.exports = (options, hot) => {
     }
     // TODO: need to embed cache hit or not 
     module._compile(agree, file);
-    if (hot) {
+    if (hot && !cached.agree) {
       delete require.cache[file];
     }
   };

--- a/packages/core/lib/require_hook/typescript.js
+++ b/packages/core/lib/require_hook/typescript.js
@@ -18,7 +18,7 @@ const takeCache = (options) => {
   try {
     if (!cache && options.typedCachePath) {
       const data = fs.readFileSync(options.typedCachePath).toString("utf-8");
-      cache = JSON.parse(cache);
+      const cache = JSON.parse(data);
       return cache;
     }
     return {};
@@ -39,13 +39,15 @@ const getCacheAgree = (file, cache, mtimeMs) => {
 const writeCacheOnExit = (options) => {
   if (options.typedCachePath) {
     process.once("exit", () => {
-      fs.writeFileSync(options.typedCachePath, JSON.stringify(cache));
+      if (cache) {
+        fs.writeFileSync(options.typedCachePath, JSON.stringify(cache));
+      }
     });
   }
 }
 
 module.exports = (options, hot) => {
-  const cache = takeCache(options);
+  cache = takeCache(options);
   writeCacheOnExit(options);
   require.extensions[".ts"] = (module, file) => {
     const { mtimeMs } = fs.statSync(file);
@@ -59,6 +61,7 @@ module.exports = (options, hot) => {
         agree,
       };
     }
+    // TODO: need to embed cache hit or not 
     module._compile(agree, file);
     if (hot) {
       delete require.cache[file];

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -33,7 +33,7 @@ class Server {
   useMiddleware(req, res, next) {
     const agrees = (
       this.agrees || requireAgree(this.agreesPath, this.options.hot)
-    ).map(agree => console.log(agree) || completion(agree, this.base, this.options));
+    ).map(agree => completion(agree, this.base, this.options));
 
     extract
       .incomingRequest(req)

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -33,7 +33,7 @@ class Server {
   useMiddleware(req, res, next) {
     const agrees = (
       this.agrees || requireAgree(this.agreesPath, this.options.hot)
-    ).map(agree => completion(agree, this.base, this.options));
+    ).map(agree => console.log(agree) || completion(agree, this.base, this.options));
 
     extract
       .incomingRequest(req)

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -13,6 +13,7 @@ const hasTemplate = require("./template/hasTemplate").hasTemplate;
 const bind = require("./template/bind");
 const requireAgree = require("./require_hook/requireAgree");
 const EventEmitter = require("events").EventEmitter;
+const AGREED_CACHE_JSON = ".agreed.json";
 
 class Server {
   constructor(options = {}) {
@@ -23,7 +24,11 @@ class Server {
     }
     this.options = options;
     this.notifier = new EventEmitter();
-    register(options.register, this.options.hot);
+    const registerOpts = { 
+      typedCachePath: options.typedCachePath,
+      ...this.options.register,
+    };
+    register(registerOpts, this.options.hot);
   }
   useMiddleware(req, res, next) {
     const agrees = (

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -13,7 +13,6 @@ const hasTemplate = require("./template/hasTemplate").hasTemplate;
 const bind = require("./template/bind");
 const requireAgree = require("./require_hook/requireAgree");
 const EventEmitter = require("events").EventEmitter;
-const AGREED_CACHE_JSON = ".agreed.json";
 
 class Server {
   constructor(options = {}) {

--- a/packages/core/test/lib/server.typedcachepath.js
+++ b/packages/core/test/lib/server.typedcachepath.js
@@ -1,0 +1,152 @@
+"use strict";
+
+const agreedServer = require("../helper/server.js");
+const http = require("http");
+const test = require("eater/runner").test;
+const AssertStream = require("assert-stream");
+const plzPort = require("plz-port");
+const assert = require("power-assert");
+const mustCall = require("must-call");
+const os = require("os");
+const fs = require("fs");
+
+test("server: POST API with ts agrees using typed cache path", () => {
+  plzPort().then(port => {
+    const dest = `${os.tmpdir()}/agrees.ts`;
+    const cachePath = `${os.tmpdir()}/.agreed.json`;
+    fs.copyFileSync("test/agrees/agrees.ts", dest);
+    const server = agreedServer({
+      path: dest,
+      port: port,
+      typedCachePath: cachePath,
+    });
+
+    server.on("listening", () => {
+      const postData = JSON.stringify({
+        message: "test"
+      });
+      const options = {
+        host: "localhost",
+        method: "POST",
+        path: "/ts-messages",
+        port: port,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postData)
+        }
+      };
+      const req = http
+        .request(options, res => {
+          const assert = new AssertStream();
+          assert.expect({ result: "test" });
+          res.pipe(assert);
+          server.close();
+        })
+        .on("error", console.error);
+
+      req.write(postData);
+      req.end();
+    });
+  });
+});
+
+test("server: POST API with ts agrees using typed cache path using cache", () => {
+  plzPort().then(port => {
+    const dest = `${os.tmpdir()}/agrees.ts`;
+    const cachePath = `${os.tmpdir()}/.agreed.json`;
+    const server = agreedServer({
+      path: dest,
+      port: port,
+      typedCachePath: cachePath,
+    });
+
+    server.on("listening", () => {
+      const postData = JSON.stringify({
+        message: "test"
+      });
+      const options = {
+        host: "localhost",
+        method: "POST",
+        path: "/ts-messages",
+        port: port,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postData)
+        }
+      };
+      const req = http
+        .request(options, res => {
+          const assert = new AssertStream();
+          assert.expect({ result: "test" });
+          res.pipe(assert);
+          server.close();
+        })
+        .on("error", console.error);
+
+      req.write(postData);
+      req.end();
+    });
+  });
+});
+
+test("server: POST API with ts agrees using typed cache path using cache", () => {
+  plzPort().then(port => {
+    const dest = `${os.tmpdir()}/agrees.ts`;
+    const cachePath = `${os.tmpdir()}/.agreed.json`;
+    const content = `
+module.exports = [{
+  request: {
+    path: '/ts-messages2',
+    method: 'POST',
+    body: {
+      message: '{:message}'
+    },
+    values: {
+      message: 'test'
+    }
+  }, 
+  response: {
+    body: {
+      result: '{:message}'
+    },
+    values: {
+      message: 'test'
+    },
+  },
+}];
+    `;
+    fs.writeFileSync(dest, content);
+    const server = agreedServer({
+      path: dest,
+      port: port,
+      typedCachePath: cachePath,
+    });
+
+    server.on("listening", () => {
+      const postData = JSON.stringify({
+        message: "test"
+      });
+      const options = {
+        host: "localhost",
+        method: "POST",
+        path: "/ts-messages2",
+        port: port,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postData)
+        }
+      };
+      const req = http
+        .request(options, res => {
+          const assert = new AssertStream();
+          assert.expect({ result: "test" });
+          res.pipe(assert);
+          server.close();
+        })
+        .on("error", console.error);
+
+      req.write(postData);
+      req.end();
+    });
+  });
+});

--- a/packages/core/test/lib/server.typedcachepath.js
+++ b/packages/core/test/lib/server.typedcachepath.js
@@ -1,3 +1,4 @@
+// eater:only
 "use strict";
 
 const agreedServer = require("../helper/server.js");
@@ -146,6 +147,38 @@ module.exports = [{
         .on("error", console.error);
 
       req.write(postData);
+      req.end();
+    });
+  });
+});
+
+test("server: use agreed-typed fixtures", () => {
+  plzPort().then(port => {
+    const cachePath = `${os.tmpdir()}/.agreed.json`;
+    const server = agreedServer({
+      path: "../typed/src/__tests__/data/agreed.ts",
+      port: port,
+      typedCachePath: cachePath,
+    });
+
+    server.on("listening", () => {
+      const options = {
+        host: "localhost",
+        method: "GET",
+        path: "/ping/test",
+        port: port,
+        headers: {
+          "Content-Type": "application/json",
+        }
+      };
+      const req = http
+        .request(options, res => {
+          const assert = new AssertStream();
+          assert.expect({ message: "ok test" });
+          res.pipe(assert);
+          server.close();
+        })
+        .on("error", console.error);
       req.end();
     });
   });

--- a/packages/core/test/lib/server.typedcachepath.js
+++ b/packages/core/test/lib/server.typedcachepath.js
@@ -1,4 +1,3 @@
-// eater:only
 "use strict";
 
 const agreedServer = require("../helper/server.js");

--- a/packages/server/bin/agreed-server.js
+++ b/packages/server/bin/agreed-server.js
@@ -10,7 +10,8 @@ const argv = minimist(process.argv.slice(2), {
     'default-response-headers',
     'default-request-headers',
     'proxy',
-    'proxy-prefix-path'
+    'proxy-prefix-path',
+    'typed-cache-path'
   ],
   boolean: ['help', 'version', 'logging', 'strict', 'hot'],
   alias: {
@@ -43,6 +44,7 @@ Options:
   -l, --logging                      Logs requests in console.
   --strict                           Run strict mode.
   --hot                              Hot Replacement agree files. Default true
+  --typed-cache-path                 Create Cached JSON to improve agreed typed performance.
 
 Examples:
   agreed-server --path ./agreed.js --port 4000
@@ -53,6 +55,8 @@ Examples:
   agreed-server --path ./agreed.js --port 4000 \\
                 --proxy example.com \\
                 --proxy-prefix-path /proxy
+  agreed-server --path ./agreed.js --port 4000 \\
+                --typed-cache-path ./.agreed.json
 `.trim();
 
 function showHelp(exitcode) {

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -22,6 +22,8 @@ module.exports = (opts) => {
   const proxy = opts.proxy;
   const proxyPrefixPath = opts['proxy-prefix-path'] || opts.proxyPrefixPath;
   const proxyOpts = opts.proxyOpts || {};
+  const typedCachePath = opts['typed-cache-path'] || opts.typedCachePath;
+  opts.typedCachePath = typedCachePath;
 
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
this option will create cache object on local path, if this cache is created, typescript compiler does not transpile every request.