### PR TITLE
Make pretty JSON on suggestion

### DIFF
--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -95,9 +95,9 @@ class Server {
             delete agree.request.pathToRegexpKeys;
             res.end(
               `Agree Not Found, actual request is ${JSON.stringify(
-                req
+                req, null, 2
               )}, but similar agree request is ${JSON.stringify(
-                agree.request
+                agree.request, null, 2
               )}, error: ${error}`
             );
           } else {


### PR DESCRIPTION
```
❯ curl localhost:1323/hoge/fuga
Agree Not Found, actual request is {
  "method": "GET",
  "path": "/hoge/fuga",
  "query": {},
  "url": "/hoge/fuga",
  "headers": {
    "host": "localhost:1323",
    "user-agent": "curl/7.54.0",
    "accept": "*/*"
  },
  "body": {}
}, but similar agree request is {
  "path": "/hoge/fuga",
  "method": "GET",
  "query": {
    "q": "foo"
  },
  "headers": {}
}, error: Does not include query, expect {"q":"foo"} but {}
```