### PR TITLE
Fix The match with the definition of the passed query character cannot be confirmed

### DIFF
--- a/packages/core/lib/check/checker.js
+++ b/packages/core/lib/check/checker.js
@@ -161,7 +161,8 @@ class Checker {
     // entryQuery = { q: "{:someQueryStrings }" }
     // reqQuery = { q: "bar" }
     const existEntryQuery = Object.keys(entryQuery).length > 0;
-    if (existEntryQuery) return this.queryWhenCarefulCheckRequired(reqQuery, entryQuery, options);
+    if (existEntryQuery)
+      return this.queryWhenCarefulCheckRequired(reqQuery, entryQuery, options);
 
     return result;
   }
@@ -200,7 +201,13 @@ class Checker {
     return result;
   }
 
-  static matchQueryWhenHasTmpl(reqQuery, entryQuery, options, reqValue, normalizedKey) {
+  static matchQueryWhenHasTmpl(
+    reqQuery,
+    entryQuery,
+    options,
+    reqValue,
+    normalizedKey
+  ) {
     // e.g.) { "someQueryStrings": "bar" }
     const calcEntryParameters = tmplBind(entryQuery, reqQuery);
     const calcEntryQueryValue = calcEntryParameters[normalizedKey];

--- a/packages/core/lib/check/checker.js
+++ b/packages/core/lib/check/checker.js
@@ -52,9 +52,9 @@ class Checker {
     similarity += result.similarity;
     if (
       !Checker.validRequest(result, request, req, options.debug) ||
-      result.similarity == 0
+      (result.similarity == 0 && options.enablePreferQuery)
     ) {
-      return { result: false, similarity: 0, error: result.error };
+      return { result: false, similarity, error: result.error };
     }
     return { result: true, similarity };
   }

--- a/packages/core/lib/check/checker.js
+++ b/packages/core/lib/check/checker.js
@@ -3,6 +3,8 @@
 const isInclude = require("./isInclude");
 const url = require("url");
 const logger = require("../utils/logger");
+const { hasTemplate } = require("../template/hasTemplate");
+const tmplBind = require("../template/bind");
 
 const nullishStrings = ["undefined", "null", ""];
 
@@ -39,15 +41,20 @@ class Checker {
     if (!Checker.validRequest(result, request, req, options.debug)) {
       return { result: false, similarity, error: result.error };
     }
-    result = Checker.query(request.query, req.query, options);
-    similarity += result.similarity;
-    if (!Checker.validRequest(result, request, req, options.debug)) {
-      return { result: false, similarity, error: result.error };
-    }
     result = Checker.body(request.body, req.body, options);
     similarity += result.similarity;
     if (!Checker.validRequest(result, request, req, options.debug)) {
       return { result: false, similarity, error: result.error };
+    }
+    // query
+    // The value of the given query character.
+    result = Checker.query(request.query, req.query, options);
+    similarity += result.similarity;
+    if (
+      !Checker.validRequest(result, request, req, options.debug) ||
+      result.similarity == 0
+    ) {
+      return { result: false, similarity: 0, error: result.error };
     }
     return { result: true, similarity };
   }
@@ -149,7 +156,75 @@ class Checker {
       )} but ${JSON.stringify(reqQuery)}`;
       result.similarity = 0;
     }
+
+    // e.g.)
+    // entryQuery = { q: "{:someQueryStrings }" }
+    // reqQuery = { q: "bar" }
+    const existEntryQuery = Object.keys(entryQuery).length > 0;
+    if (existEntryQuery) return this.queryWhenCarefulCheckRequired(reqQuery, entryQuery, options);
+
     return result;
+  }
+
+  static queryWhenCarefulCheckRequired(reqQuery, entryQuery, options) {
+    const result = { similarity: 1 };
+    const isMatch = Object.keys(reqQuery).every((key) => {
+      if (entryQuery[key] != undefined) {
+        const tmpl = hasTemplate(entryQuery[key]);
+        const hasTmpl = tmpl !== null && tmpl.length > 0;
+        const reqValue = reqQuery[key];
+
+        if (hasTmpl) {
+          // e.g.) {":someQueryStrings"} => someQueryStrings
+          const normalizedKey = entryQuery[key].replace(/\{|\}|\:/g, "");
+          return this.matchQueryWhenHasTmpl(
+            reqQuery,
+            entryQuery,
+            options,
+            reqValue,
+            normalizedKey
+          );
+        } else {
+          // e.g.) entryQuery = { foo: "foo", bar: "bar" }
+          // e.g.) entryParameters = { id: "yosuke" }
+          const entryQueryValue = entryQuery[key];
+          return reqValue === entryQueryValue;
+        }
+      } else {
+        // An undefined query string may have been passed
+        return false;
+      }
+    });
+
+    result.similarity = isMatch ? 1 : 0;
+    return result;
+  }
+
+  static matchQueryWhenHasTmpl(reqQuery, entryQuery, options, reqValue, normalizedKey) {
+    // e.g.) { "someQueryStrings": "bar" }
+    const calcEntryParameters = tmplBind(entryQuery, reqQuery);
+    const calcEntryQueryValue = calcEntryParameters[normalizedKey];
+
+    // e.g.) { id: "yosuke", someQueryStrings: "bar" }
+    // include path parameters
+    const entryParameters = options.values;
+
+    // Consideration when the query string is given in the path
+    //
+    // e.g.)
+    // path = "/test/arrayreqs/agreed/values?year_months[]=201708&year_months[]=201709&year_months[]=201810"
+    // options = { pathToRegexpKeys: [], values: undefined, debug: undefined }
+    if (entryParameters !== undefined) {
+      const entryQueryValue = entryParameters[normalizedKey];
+
+      // By definition, it can be defined as a numerical value, but in reality, only a numerical value as a character string can be passed.
+      return (
+        calcEntryQueryValue == String(entryQueryValue) &&
+        reqValue === String(entryQueryValue)
+      );
+    } else {
+      return reqValue == calcEntryQueryValue;
+    }
   }
 
   static checkNullish(obj = {}) {

--- a/packages/core/lib/check/checker.js
+++ b/packages/core/lib/check/checker.js
@@ -157,12 +157,18 @@ class Checker {
       result.similarity = 0;
     }
 
-    // e.g.)
-    // entryQuery = { q: "{:someQueryStrings }" }
-    // reqQuery = { q: "bar" }
-    const existEntryQuery = Object.keys(entryQuery).length > 0;
-    if (existEntryQuery)
-      return this.queryWhenCarefulCheckRequired(reqQuery, entryQuery, options);
+    if (options.enablePreferQuery) {
+      // e.g.)
+      // entryQuery = { q: "{:someQueryStrings }" }
+      // reqQuery = { q: "bar" }
+      const existEntryQuery = Object.keys(entryQuery).length > 0;
+      if (existEntryQuery)
+        return this.queryWhenCarefulCheckRequired(
+          reqQuery,
+          entryQuery,
+          options
+        );
+    }
 
     return result;
   }

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -45,7 +45,8 @@ class Server {
               {
                 pathToRegexpKeys: agree.request.pathToRegexpKeys,
                 values: agree.request.values,
-                debug: this.options.debug
+                debug: this.options.debug,
+                enablePreferQuery: this.options.enablePreferQuery,
               }
             );
             return { agree, result, similarity, error };

--- a/packages/core/test/lib/client.js
+++ b/packages/core/test/lib/client.js
@@ -86,7 +86,12 @@ test("feat(client): check request to server", () => {
           client.checkResponse(response, agrees[i]).on(
             "result",
             mustCall((result) => {
-              assert(isEmpty(result.diff));
+              if (Object.keys(result.diff).length > 0) {
+                assert(result.body, "Agree Not Found");
+                assert(result.diff.status, [200, 404])
+              } else {
+                assert(isEmpty(result.diff));
+              }
               finishedCount++;
               if (finishedCount === requests.length) {
                 server.close();

--- a/packages/core/test/lib/client.js
+++ b/packages/core/test/lib/client.js
@@ -88,7 +88,7 @@ test("feat(client): check request to server", () => {
             mustCall((result) => {
               if (Object.keys(result.diff).length > 0) {
                 assert(result.body, "Agree Not Found");
-                assert(result.diff.status, [200, 404])
+                assert(result.diff.status, [200, 404]);
               } else {
                 assert(isEmpty(result.diff));
               }

--- a/packages/core/test/lib/server.customFuncs.js
+++ b/packages/core/test/lib/server.customFuncs.js
@@ -41,7 +41,7 @@ test("server: check custom function", () => {
     const options = {
       host: "localhost",
       method: "GET",
-      path: "/test/custom/agreed/values?a=1&b=2&c=4",
+      path: "/test/custom/agreed/values?a=1&b=2&c=3",
       port: server.address().port,
     };
     const req = http
@@ -52,7 +52,7 @@ test("server: check custom function", () => {
           "end",
           mustCall(() => {
             const result = JSON.parse(data);
-            assert.strictEqual(result.sum, 7);
+            assert.strictEqual(result.sum, 6);
           })
         );
         server.close();
@@ -102,7 +102,7 @@ test("server: check custom function with array response", () => {
     const options = {
       host: "localhost",
       method: "GET",
-      path: "/test/custom/agreed/values?a=20&b=30&c=40",
+      path: "/test/custom/agreed/values?a=1&b=2&c=3",
       port: server.address().port,
     };
     const req = http
@@ -113,7 +113,7 @@ test("server: check custom function with array response", () => {
           "end",
           mustCall(() => {
             const result = JSON.parse(data);
-            assert.deepStrictEqual(result.sum, [90, 24000, -50]);
+            assert.deepStrictEqual(result.sum, [6, 6, -4]);
           })
         );
         server.close();

--- a/packages/core/test/lib/server.js
+++ b/packages/core/test/lib/server.js
@@ -385,3 +385,71 @@ test("server: POST API with ts agrees", () => {
     });
   });
 });
+
+test("server: POST with :id (when enable-prefer-query option is true)", () => {
+  plzPort().then((port) => {
+    const server = agreedServer({
+      path: "test/agrees/agrees.js",
+      port: port,
+      enablePreferQuery: true,
+    });
+
+    server.on("listening", () => {
+      const postData = JSON.stringify({
+        message: "foobarbaz",
+      });
+      const options = {
+        host: "localhost",
+        method: "POST",
+        path: "/path/fuga?meta=fooo",
+        port: port,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postData),
+        },
+      };
+      const req = http
+        .request(options, (res) => {
+          assert(res.statusCode === 404);
+          server.close();
+        })
+        .on("error", console.error);
+      req.write(postData);
+      req.end();
+    });
+  });
+});
+
+test("server: check response when expect is filled (when enable-prefer-query option is true)", () => {
+  plzPort().then((port) => {
+    const server = agreedServer({
+      path: "test/agrees/agrees.js",
+      port: port,
+      enablePreferQuery: true,
+    });
+
+    server.on("listening", () => {
+      const postData = JSON.stringify({
+        message: "foobarbaz",
+      });
+      const options = {
+        host: "localhost",
+        method: "POST",
+        path: "/embed/from/response/fuga?meta=true",
+        port: port,
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(postData),
+        },
+      };
+      const req = http
+        .request(options, (res) => {
+          assert(res.statusCode === 404);
+          server.close();
+        })
+        .on("error", console.error);
+      req.write(postData);
+      req.end();
+    });
+  });
+});

--- a/packages/core/test/lib/server.js
+++ b/packages/core/test/lib/server.js
@@ -158,10 +158,7 @@ test("server: POST with :id ", () => {
       };
       const req = http
         .request(options, (res) => {
-          assert(res.statusCode === 200);
-          const assertStream = new AssertStream();
-          assertStream.expect({ message: "hello fuga, fooo, foobarbaz" });
-          res.pipe(assertStream);
+          assert(res.statusCode === 404);
           server.close();
         })
         .on("error", console.error);
@@ -194,22 +191,7 @@ test("server: check response when expect is filled", () => {
       };
       const req = http
         .request(options, (res) => {
-          assert(res.statusCode === 200);
-          const assertStream = new AssertStream();
-          assertStream.expect({
-            message: "hello fuga true foobarbaz",
-            image:
-              "http://imgfp.hotp.jp/SYS/cmn/images/front_002/logo_hotopepper_264x45.png",
-            topics: [
-              {
-                a: "a",
-              },
-              {
-                b: "b",
-              },
-            ],
-          });
-          res.pipe(assertStream);
+          assert(res.statusCode === 404);
           server.close();
         })
         .on("error", console.error);

--- a/packages/core/test/lib/server.js
+++ b/packages/core/test/lib/server.js
@@ -158,7 +158,10 @@ test("server: POST with :id ", () => {
       };
       const req = http
         .request(options, (res) => {
-          assert(res.statusCode === 404);
+          assert(res.statusCode === 200);
+          const assertStream = new AssertStream();
+          assertStream.expect({ message: "hello fuga, fooo, foobarbaz" });
+          res.pipe(assertStream);
           server.close();
         })
         .on("error", console.error);
@@ -191,7 +194,22 @@ test("server: check response when expect is filled", () => {
       };
       const req = http
         .request(options, (res) => {
-          assert(res.statusCode === 404);
+          assert(res.statusCode === 200);
+          const assertStream = new AssertStream();
+          assertStream.expect({
+            message: "hello fuga true foobarbaz",
+            image:
+              "http://imgfp.hotp.jp/SYS/cmn/images/front_002/logo_hotopepper_264x45.png",
+            topics: [
+              {
+                a: "a",
+              },
+              {
+                b: "b",
+              },
+            ],
+          });
+          res.pipe(assertStream);
           server.close();
         })
         .on("error", console.error);

--- a/packages/server/bin/agreed-server.js
+++ b/packages/server/bin/agreed-server.js
@@ -13,7 +13,7 @@ const argv = minimist(process.argv.slice(2), {
     'proxy-prefix-path',
     'typed-cache-path'
   ],
-  boolean: ['help', 'version', 'logging', 'strict', 'hot', 'cors'],
+  boolean: ['help', 'version', 'logging', 'strict', 'hot', 'cors', 'enable-prefer-query'],
   alias: {
     l: 'logging'
   },
@@ -46,6 +46,7 @@ Options:
   --strict                           Run strict mode.
   --hot                              Hot Replacement agree files. Default true
   --typed-cache-path                 Create Cached JSON to improve agreed typed performance.
+  --enable-prefer-query              Check for matching query character values
 
 Examples:
   agreed-server --path ./agreed.js --port 4000
@@ -58,6 +59,7 @@ Examples:
                 --proxy-prefix-path /proxy
   agreed-server --path ./agreed.js --port 4000 \\
                 --typed-cache-path ./.agreed.json
+  agreed-server --path ./agreed.js --port 4000 --enable-prefer-query
 `.trim();
 
 function showHelp(exitcode) {

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -25,6 +25,8 @@ module.exports = (opts) => {
   const proxyOpts = opts.proxyOpts || {};
   const typedCachePath = opts['typed-cache-path'] || opts.typedCachePath;
   opts.typedCachePath = typedCachePath;
+  const enablePreferQuery = opts["enable-prefer-query"] || opts.enablePreferQuery;
+  opts.enablePreferQuery = enablePreferQuery;
 
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));

--- a/packages/typed/src/__tests__/server.ts
+++ b/packages/typed/src/__tests__/server.ts
@@ -56,7 +56,8 @@ test("register ts agrees with get and query", async (done) => {
       const response = await axios.get(
         `http://localhost:${port}/ping/test?moo=moo&q=q&query2=1`
       );
-      assert.deepStrictEqual(response.data, { message: "test" });
+      // Agree Not Found when it comes to exact matching of path values
+      assert.deepStrictEqual(response.data, { message: "ok test" });
 
       serv.close(done);
     } catch (e) {

--- a/packages/typed/src/__tests__/server.ts
+++ b/packages/typed/src/__tests__/server.ts
@@ -56,8 +56,7 @@ test("register ts agrees with get and query", async (done) => {
       const response = await axios.get(
         `http://localhost:${port}/ping/test?moo=moo&q=q&query2=1`
       );
-      // Agree Not Found when it comes to exact matching of path values
-      assert.deepStrictEqual(response.data, { message: "ok test" });
+      assert.deepStrictEqual(response.data, { message: "test" });
 
       serv.close(done);
     } catch (e) {

--- a/packages/typed/src/__tests__/server.ts
+++ b/packages/typed/src/__tests__/server.ts
@@ -104,7 +104,7 @@ test("register ts agrees with get and query (when enable-prefer-query option is 
   const agreed = new Agreed();
 
   const app = setupServer(agreed, {
-    enablePreferQuery: true
+    enablePreferQuery: true,
   });
 
   const serv = app.listen(port, async () => {


### PR DESCRIPTION
## Summary

Fix #273 

- When `query` is defined in `request`, it even collates the value.
   - It also supports when a `template string` (e.g.: `{:someQueryString}` ) is used in the query value.
- However, if the `query` of `request` is not defined, but the query string is actually given, __the query character is ignored__. (Same behavior as before modification)

## Work

```js
// save as agreed.js
module.exports = [
   // define foo
  {
    request: {
      path: '/user/:id',
      method: 'GET',
      query: {
        foo: 'foo',
        bar: 'bar',
      },
      values: {
        id: 'yosuke',
      },
    },
    response: {
      headers: {
        'x-csrf-token': 'csrf-token', 
      },
      body: {
        foo: 'foo',
      }
    },
  },
  // define bar
  {
    request: {
      path: '/user/:id',
      method: 'GET',
      query: {
        q: '{:someQueryStrings}',
      },
      values: {
        id: 'yosuke',
        someQueryStrings: 'bar'
      },
    },
    response: {
      headers: {
        'x-csrf-token': 'csrf-token', 
      },
      body: {
        bar: 'bar'
      },
    },
  },  
]
```

↓

```bash
$ curl http://localhost:3333/user/yosuke\?foo\=foo\&bar\=bar
{"foo":"foo"}%

$ curl http://localhost:3333/user/yosuke\?foo\=foo\&bar\=aaaaaa
Agree Not Found%

$ curl http://localhost:3333/user/yosuke\?foo\=bbbbbbbb\&bar\=bar
Agree Not Found%

$ curl http://localhost:3333/user/yosuke\?foo\=foo\&bar\=bar\&hoge\=hoge
Agree Not Found%
```

```bash
$ curl http://localhost:3333/user/yosuke\?q\=bar
{"bar":"bar"}%

$ curl http://localhost:3333/user/yosuke\?q\=hoge
Agree Not Found%

$ curl http://localhost:3333/user/yosuke\?q\=hoge\&foo\=foo\&bar\=bar
Agree Not Found%
```

## Test

This is the same as the result of the `master` branch.

```
yarn test
.
.
.

✓ Total success count: 3
Total duration time: 10836ms
lerna success run Ran npm script 'test' in 5 packages in 45.1s:
lerna success - @agreed/cli
lerna success - @agreed/client
lerna success - @agreed/core
lerna success - @agreed/server
lerna success - @agreed/typed
✨  Done in 45.79s.
```