### PR TITLE
fix: fix error when the request value in agreed file is null

### DIFF
--- a/packages/core/lib/check/isInclude.js
+++ b/packages/core/lib/check/isInclude.js
@@ -9,7 +9,7 @@ module.exports = function isInclude(small, large) {
     return small.getTime() === large.getTime();
   }
 
-  if (typeof small != "object") {
+  if (typeof small != "object" || small === null) {
     if (hasTemplate(small) && large !== undefined) {
       return true;
     }

--- a/packages/core/test/lib/check/isInclude.js
+++ b/packages/core/test/lib/check/isInclude.js
@@ -96,3 +96,60 @@ test("isInclude: false, check large value is empty string", () => {
   const is = isInclude(small, large);
   assert(!is);
 });
+
+test("isInclude: check small value is null & large value is null", () => {
+  const small = {
+    abc: "abc",
+    def: "{:aaa}",
+    ghi: "{:hoo}",
+    jkl: null
+  };
+
+  const large = {
+    abc: "abc",
+    def: { a: "123" },
+    ghi: "",
+    jkl: null
+  };
+
+  const is = isInclude(small, large);
+  assert(is);
+});
+
+test("isInclude: check small value is null & large value is undefined", () => {
+  const small = {
+    abc: "abc",
+    def: "{:aaa}",
+    ghi: "{:hoo}",
+    jkl: null
+  };
+
+  const large = {
+    abc: "abc",
+    def: { a: "123" },
+    ghi: ""
+    // jkl is undefined
+  };
+
+  const is = isInclude(small, large);
+  assert(is);
+});
+
+test("isInclude: false, check small value is null & large value is empty string", () => {
+  const small = {
+    abc: "abc",
+    def: "{:aaa}",
+    ghi: "{:hoo}",
+    jkl: null
+  };
+
+  const large = {
+    abc: "abc",
+    def: { a: "123" },
+    ghi: "",
+    jkl: ""
+  };
+
+  const is = isInclude(small, large);
+  assert(!is);
+});


### PR DESCRIPTION
##  Problem
When the request value in an agreed file includes `null` value in one of its fields,
the following error occurs:
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at isInclude (/Users/uu119619/git/shift/fe/airshift/node_modules/@agreed/core/lib/check/isInclude.js:29:24)
    at isInclude (/Users/uu119619/git/shift/fe/airshift/node_modules/@agreed/core/lib/check/isInclude.js:31:10)
    at Function.body (/Users/uu119619/git/shift/fe/airshift/node_modules/@agreed/core/lib/check/checker.js:132:10)
    at Function.request (/Users/uu119619/git/shift/fe/airshift/node_modules/@agreed/core/lib/check/checker.js:47:22)
    at /Users/uu119619/git/shift/fe/airshift/node_modules/@agreed/core/lib/server.js:39:59
    at Array.map (<anonymous>)
    at /Users/uu119619/git/shift/fe/airshift/node_modules/@agreed/core/lib/server.js:38:18
```

## Cause
[isInclude function](https://github.com/nk-hashimoto/agreed/blob/master/packages/core/lib/check/isInclude.js#L12) checks if the agreed file value (small) is object by evaluating `typeof small`.
`typeof null` is `object`, so when `small` is null, it is regarded as an object and the code tries to recursively call `isInclude` for its keys, which causes the error. 

## Solution
Added null check to the condition of object distinction:
`typeof small != "object"` -> `typeof small != "object" || small === null`