### PR TITLE
I want HTTP Header value to be accepted as empty

### DIFF
--- a/packages/core/lib/check/checker.js
+++ b/packages/core/lib/check/checker.js
@@ -121,14 +121,16 @@ class Checker {
       return result;
     }
 
-    const nullish = Checker.checkNullish(reqHeaders);
-    const nullishError = nullish.error;
-    const nullishSimilarity = nullish.similarity;
-    if (nullish) {
-      result.type = "HEADERS";
-      result.error = nullishError;
-      result.similarity = nullishSimilarity;
-      return result;
+    if (!options.skipCheckHeaderValueNullable) {
+      const nullish = Checker.checkNullish(reqHeaders);
+      const nullishError = nullish.error;
+      const nullishSimilarity = nullish.similarity;
+      if (nullish) {
+        result.type = "HEADERS";
+        result.error = nullishError;
+        result.similarity = nullishSimilarity;
+        return result;
+      }
     }
     return result;
   }

--- a/packages/core/lib/server.js
+++ b/packages/core/lib/server.js
@@ -47,6 +47,7 @@ class Server {
                 values: agree.request.values,
                 debug: this.options.debug,
                 enablePreferQuery: this.options.enablePreferQuery,
+                skipCheckHeaderValueNullable: this.options.skipCheckHeaderValueNullable,
               }
             );
             return { agree, result, similarity, error };

--- a/packages/core/test/lib/server.emptyHeaderValue.js
+++ b/packages/core/test/lib/server.emptyHeaderValue.js
@@ -25,7 +25,7 @@ test("server: check empty-header-value skip", () => {
       },
     ],
     port: 0,
-    skipCheckHeaderValueNullable: true
+    skipCheckHeaderValueNullable: true,
   });
 
   server.on("listening", () => {
@@ -35,7 +35,7 @@ test("server: check empty-header-value skip", () => {
       path: "/test/agreed/1",
       port: server.address().port,
       headers: {
-        'empty-header': ''
+        "empty-header": "",
       },
     };
     const req = http
@@ -49,7 +49,7 @@ test("server: check empty-header-value skip", () => {
               const result = JSON.parse(data);
               assert.strictEqual(result.id, 1);
             } catch (e) {
-              console.error()
+              console.error();
             }
           })
         );
@@ -79,7 +79,7 @@ test("server: check empty-header-value fail", () => {
       },
     ],
     port: 0,
-    skipCheckHeaderValueNullable: false
+    skipCheckHeaderValueNullable: false,
   });
 
   server.on("listening", () => {
@@ -89,8 +89,8 @@ test("server: check empty-header-value fail", () => {
       path: "/test/agreed/1",
       port: server.address().port,
       headers: {
-        'empty-header': ''
-      }
+        "empty-header": "",
+      },
     };
     const req = http
       .request(options, (res) => {

--- a/packages/core/test/lib/server.emptyHeaderValue.js
+++ b/packages/core/test/lib/server.emptyHeaderValue.js
@@ -101,9 +101,9 @@ test("server: check empty-header-value fail", () => {
           mustCall(() => {
             try {
               const result = JSON.parse(data);
+              assert.fail("shoul not be reached here.");
             } catch (e) {
-              // fail is OK
-              assert.strictEqual(1, 1);
+              // noop.
             }
           })
         );

--- a/packages/core/test/lib/server.emptyHeaderValue.js
+++ b/packages/core/test/lib/server.emptyHeaderValue.js
@@ -1,0 +1,116 @@
+"use strict";
+
+const agreedServer = require("../helper/server.js");
+const test = require("eater/runner").test;
+const http = require("http");
+const AssertStream = require("assert-stream");
+const assert = require("power-assert");
+const mustCall = require("must-call");
+
+test("server: check empty-header-value skip", () => {
+  const server = agreedServer({
+    agrees: [
+      {
+        request: {
+          path: "/test/agreed/:id",
+          values: {
+            id: 1,
+          },
+        },
+        response: {
+          body: {
+            id: 1,
+          },
+        },
+      },
+    ],
+    port: 0,
+    skipCheckHeaderValueNullable: true
+  });
+
+  server.on("listening", () => {
+    const options = {
+      host: "localhost",
+      method: "GET",
+      path: "/test/agreed/1",
+      port: server.address().port,
+      headers: {
+        'empty-header': ''
+      },
+    };
+    const req = http
+      .request(options, (res) => {
+        let data = "";
+        res.on("data", (d) => (data += d));
+        res.on(
+          "end",
+          mustCall(() => {
+            try {
+              const result = JSON.parse(data);
+              assert.strictEqual(result.id, 1);
+            } catch (e) {
+              console.error()
+            }
+          })
+        );
+        server.close();
+      })
+      .on("error", console.error);
+
+    req.end();
+  });
+});
+
+test("server: check empty-header-value fail", () => {
+  const server = agreedServer({
+    agrees: [
+      {
+        request: {
+          path: "/test/agreed/:id",
+          values: {
+            id: 1,
+          },
+        },
+        response: {
+          body: {
+            id: 1,
+          },
+        },
+      },
+    ],
+    port: 0,
+    skipCheckHeaderValueNullable: false
+  });
+
+  server.on("listening", () => {
+    const options = {
+      host: "localhost",
+      method: "GET",
+      path: "/test/agreed/1",
+      port: server.address().port,
+      headers: {
+        'empty-header': ''
+      }
+    };
+    const req = http
+      .request(options, (res) => {
+        let data = "";
+        res.on("data", (d) => (data += d));
+        res.on(
+          "end",
+          mustCall(() => {
+            try {
+              const result = JSON.parse(data);
+            } catch (e) {
+              // fail is OK
+              assert.strictEqual(1, 1);
+            }
+          })
+        );
+        server.close();
+      })
+      .on("error", console.error);
+
+    req.end();
+  });
+});


### PR DESCRIPTION
I have a case where I want the HTTP Header value to be empty, and I want to solve the problem of Checker not allowing empty values.

Error Response

```
{"status":404,"headers":{"x-powered-by":"Express","date":"Wed, 20 Jul 2022 14:01:38 GMT","connection":"close","content-length":"1004"},"data":"Agree Not Found, actual request is {
  /* failed request */
}, error: Request value has nullish strings  in bf-backend-session-id","statusText":"Not Found","req":{"ip":"::1","method":"POST","url":"/path/to/url","originalUrl":"/path/to/url","xForwardedFor":"-"}}
```

This is because the checker does not allow the value to be null.

https://github.com/recruit-tech/agreed/blob/ff9f118ec2db3f97190f71743ccd05b033f52ba7/packages/core/lib/check/checker.js#L112-L134

Request Example: I want to send the value of the extension header empty before login

```typescript
{
    request: {
      path: '/path/to/not-login',
      method: 'POST',
      headers: {
        "x-session-id": "",
        "x-user-id": "",
        "x-apibearer": "secret"
      },
      query: {},
      body: {
        login_id: 'success@example.com',
        password: '{:password}',
      },
    },
    response: {
      status: 200,
      body: {
        session_id: 'xxxxxxxxx',
        user_id: 1234,
        authenticated_at: '2050-01-01T14:26:58+0900',
      },
    },
  },
}
```

Added as a skip option for backward compatibility
I would be glad if you could accept it!