### PR TITLE
[typed] experimental fixed: use TJS.getProgramFromSource insteadof ts.createProgram

### DIFF
--- a/packages/typed/src/generate-schema.ts
+++ b/packages/typed/src/generate-schema.ts
@@ -44,7 +44,7 @@ export function generateSchema(fileNames, meta): Spec[] {
   };
   host.getSourceFileByPath = undefined;
 
-  const program = ts.createProgram(fileNames, compilerOptions, host);
+  const program = TJS.getProgramFromFiles(fileNames, compilerOptions);
 
   const generator = TJS.buildGenerator(program as unknown as TJS.Program, settings);
   return meta.map(m => {


### PR DESCRIPTION
I am not sure this fix is good. 
But gen-swagger works well.